### PR TITLE
table winners  and logic for automatically creating winner

### DIFF
--- a/src/main/java/ani/beautymarathon/controller/MeasurementController.java
+++ b/src/main/java/ani/beautymarathon/controller/MeasurementController.java
@@ -1,5 +1,6 @@
 package ani.beautymarathon.controller;
 
+import ani.beautymarathon.entity.ClosedState;
 import ani.beautymarathon.entity.DeletedState;
 import ani.beautymarathon.entity.MoMeasurement;
 import ani.beautymarathon.entity.User;
@@ -28,9 +29,12 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -138,6 +142,49 @@ public class MeasurementController {
     ) {
         return measurementService.getAllUserMeasurements(filter, pageable)
                 .map(this::constructUserMeasurementView);
+    }
+
+    @PutMapping("/wk/status/{id}")
+    @Operation(summary = "Update week status by ID",
+            description = """
+                     This operation updates the status of the week for the given ID to either "OPEN" or "CLOSED".
+                    A "CLOSED" week is read-only.""",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "WkMeasurement status is updated"),
+                    @ApiResponse(responseCode = "400", description = "Invalid input",
+                            content = @Content(schema = @Schema())),
+                    @ApiResponse(responseCode = "500", description = "Server error",
+                            content = @Content(schema = @Schema()))
+            })
+    public GetWkMeasurementView updateWkStatus(@PathVariable Long id, @RequestParam("newState") ClosedState newState) {
+        final WkMeasurement updated = measurementService.updateWkStatus(id, newState);
+        return constructWeekMeasurementView(updated);
+    }
+
+    @PutMapping("/mo/status/{moId}")
+    @Operation(summary = "Update month status by ID",
+            description = """
+                     This operation updates the status of the month for the given ID to either "OPEN" or "CLOSED".
+                    A "CLOSED" week is read-only.""",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "MoMeasurement status is updated"),
+                    @ApiResponse(responseCode = "400", description = "Invalid input",
+                            content = @Content(schema = @Schema())),
+                    @ApiResponse(responseCode = "500", description = "Server error",
+                            content = @Content(schema = @Schema()))
+            })
+    public GetMoMeasurementView updateMoStatus(@PathVariable Long moId, @RequestParam("newState") ClosedState newState) {
+        final MoMeasurement updated = measurementService.updateMoStatus(moId, newState);
+        return constructMoMeasurementView(updated);
+    }
+
+    private GetMoMeasurementView constructMoMeasurementView(MoMeasurement moMeasurement) {
+        return new GetMoMeasurementView(
+                moMeasurement.getId(),
+                moMeasurement.getClosedState(),
+                moMeasurement.getYear(),
+                moMeasurement.getMonthNumber()
+        );
     }
 
     private GetWkMeasurementView constructWeekMeasurementView(WkMeasurement wkMeasurement) {

--- a/src/main/java/ani/beautymarathon/controller/MeasurementController.java
+++ b/src/main/java/ani/beautymarathon/controller/MeasurementController.java
@@ -17,6 +17,7 @@ import ani.beautymarathon.view.measurement.CreateWkMeasurementView;
 import ani.beautymarathon.view.measurement.GetMoMeasurementView;
 import ani.beautymarathon.view.measurement.GetUserMeasurementView;
 import ani.beautymarathon.view.measurement.GetWkMeasurementView;
+import ani.beautymarathon.view.measurement.UpdateUserMeasurementView;
 import ani.beautymarathon.view.measurement.filter.register.MoMeasurementFilter;
 import ani.beautymarathon.view.measurement.filter.register.UserMeasurementFilter;
 import io.swagger.v3.oas.annotations.Operation;
@@ -176,6 +177,24 @@ public class MeasurementController {
     public GetMoMeasurementView updateMoStatus(@PathVariable Long moId, @RequestParam("newState") ClosedState newState) {
         final MoMeasurement updated = measurementService.updateMoStatus(moId, newState);
         return constructMoMeasurementView(updated);
+    }
+
+    @PutMapping("/user/update/{id}")
+    @Operation(summary = "Update user measurement by ID",
+            description = """
+                     This operation updates a measurement for the given ID.""",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "UserMeasurement is updated"),
+                    @ApiResponse(responseCode = "400", description = "Invalid input",
+                            content = @Content(schema = @Schema())),
+                    @ApiResponse(responseCode = "500", description = "Server error",
+                            content = @Content(schema = @Schema()))
+            })
+    public GetUserMeasurementView updateUserMeasurementView(
+            @PathVariable Long id, @RequestBody UpdateUserMeasurementView userMeasurementView
+    ) {
+        final UserMeasurement updatedUser = measurementService.updateMeasurement(id, userMeasurementView);
+        return constructUserMeasurementView(updatedUser);
     }
 
     private GetMoMeasurementView constructMoMeasurementView(MoMeasurement moMeasurement) {

--- a/src/main/java/ani/beautymarathon/controller/MeasurementController.java
+++ b/src/main/java/ani/beautymarathon/controller/MeasurementController.java
@@ -165,7 +165,7 @@ public class MeasurementController {
     @Operation(summary = "Update month status by ID",
             description = """
                      This operation updates the status of the month for the given ID to either "OPEN" or "CLOSED".
-                    A "CLOSED" week is read-only.""",
+                    A "CLOSED" month is read-only.""",
             responses = {
                     @ApiResponse(responseCode = "200", description = "MoMeasurement status is updated"),
                     @ApiResponse(responseCode = "400", description = "Invalid input",

--- a/src/main/java/ani/beautymarathon/controller/WinnerController.java
+++ b/src/main/java/ani/beautymarathon/controller/WinnerController.java
@@ -18,6 +18,4 @@ public class WinnerController {
     public WinnerController(WinnerService winnerService) {
         this.winnerService = winnerService;
     }
-
-
 }

--- a/src/main/java/ani/beautymarathon/controller/WinnerController.java
+++ b/src/main/java/ani/beautymarathon/controller/WinnerController.java
@@ -1,0 +1,23 @@
+package ani.beautymarathon.controller;
+
+import ani.beautymarathon.service.WinnerService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(
+        name = "Winner controllers",
+        description = "Controllers for all operations with winners"
+)
+@RequestMapping("/winners")
+public class WinnerController {
+
+    private final WinnerService winnerService;
+
+    public WinnerController(WinnerService winnerService) {
+        this.winnerService = winnerService;
+    }
+
+
+}

--- a/src/main/java/ani/beautymarathon/entity/Winner.java
+++ b/src/main/java/ani/beautymarathon/entity/Winner.java
@@ -1,0 +1,53 @@
+package ani.beautymarathon.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "winner")
+public class Winner {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "mo_measurement_id")
+    private MoMeasurement moMeasurement;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "average_point", updatable = false)
+    private Double averagePoint;
+
+    @Column(name = "creation_date")
+    private LocalDate creationDate;
+
+    @Override
+    public String toString() {
+        return "Winner of " + moMeasurement.getMonthNumber() +
+                ", " + moMeasurement.getYear() +
+                ": user " + user + ", " + user.getName() +
+                "with averagePoint: " + averagePoint;
+    }
+}

--- a/src/main/java/ani/beautymarathon/entity/WkMeasurement.java
+++ b/src/main/java/ani/beautymarathon/entity/WkMeasurement.java
@@ -35,9 +35,9 @@ public class WkMeasurement {
     @Column(name = "closed_state")
     private ClosedState closedState = ClosedState.OPEN;
 
+
     @Column(name = "commentary")
     private String commentary;
-
     @ManyToOne
     @JoinColumn(name = "mo_measurement_id")
     private MoMeasurement moMeasurement;

--- a/src/main/java/ani/beautymarathon/repository/WinnerRepository.java
+++ b/src/main/java/ani/beautymarathon/repository/WinnerRepository.java
@@ -1,0 +1,32 @@
+package ani.beautymarathon.repository;
+
+import ani.beautymarathon.entity.Winner;
+import ani.beautymarathon.view.UserMaxAverageView;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface WinnerRepository extends JpaRepository<Winner, Long> {
+
+    @Query(value = """
+        WITH user_avg AS (
+          SELECT
+              um.user_id,
+              AVG(um.total_point) AS average_score
+          FROM user_measurement um
+          JOIN public.wk_measurement wm ON wm.id = um.wk_measurement_id
+          JOIN public.mo_measurement mm ON mm.id = wm.mo_measurement_id
+          WHERE mm.id = :moId
+          GROUP BY um.user_id
+        )
+        SELECT user_id AS userId, average_score AS maxAverageTotal
+        FROM user_avg
+        WHERE average_score = (SELECT MAX(average_score) FROM user_avg)
+        """,
+            nativeQuery = true)
+    List<UserMaxAverageView> findUsersWithMaxAverage(@Param("moId") Long moId);
+}

--- a/src/main/java/ani/beautymarathon/service/MeasurementService.java
+++ b/src/main/java/ani/beautymarathon/service/MeasurementService.java
@@ -16,6 +16,7 @@ import ani.beautymarathon.repository.WinnerRepository;
 import ani.beautymarathon.repository.WkMeasurementRepository;
 import ani.beautymarathon.view.UserMaxAverageView;
 import ani.beautymarathon.view.measurement.CreateUserMeasurementView;
+import ani.beautymarathon.view.measurement.UpdateUserMeasurementView;
 import ani.beautymarathon.view.measurement.filter.register.MoMeasurementFilter;
 import ani.beautymarathon.view.measurement.filter.register.UserMeasurementFilter;
 import jakarta.persistence.EntityNotFoundException;
@@ -176,6 +177,38 @@ public class MeasurementService {
 
         }
     }
+
+    public UserMeasurement getMeasurementById(long id) {
+        return userMeasurementRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("User measurement with id " + id + " not found"));
+    }
+
+    public UserMeasurement updateMeasurement(
+            long id, UpdateUserMeasurementView userMeasurementView
+    ) {
+
+        final UserMeasurement userMeasurement = getMeasurementById(id);
+        final WkMeasurement wkMeasurement = userMeasurement.getWkMeasurement();
+
+        if(ClosedState.CLOSED.equals(wkMeasurement.getClosedState())) {
+            throw new WkMeasurementClosedException(
+                    "The week is closed. Please open the week for updating the measurement.");
+        }
+
+        userMeasurement.setWeight(userMeasurementView.weight());
+        userMeasurement.setWaterPoint(userMeasurementView.waterPoint());
+        userMeasurement.setCommentary(userMeasurementView.commentary());
+        userMeasurement.setDiaryPoint(userMeasurementView.diaryPoint());
+        userMeasurement.setAlcoholFreePoint(userMeasurementView.alcoholFreePoints());
+        userMeasurement.setSleepPoint(userMeasurementView.sleepPoint());
+        userMeasurement.setStepPoint(userMeasurementView.stepPoint());
+        userMeasurement.setWaterPoint(userMeasurementView.waterPoint());
+
+        final UserMeasurement updatedUserMeasurement = userMeasurementRepository.save(userMeasurement);
+        log.info("User with id {} has been updated {}", id, updatedUserMeasurement);
+        return updatedUserMeasurement;
+    }
+
 
     private Page<UserMeasurement> searchUserMeasurementsByQbe(UserMeasurementFilter filter, Pageable pageable) {
         final var probe = new UserMeasurement();

--- a/src/main/java/ani/beautymarathon/service/MeasurementService.java
+++ b/src/main/java/ani/beautymarathon/service/MeasurementService.java
@@ -12,7 +12,9 @@ import ani.beautymarathon.exception.WkMeasurementClosedException;
 import ani.beautymarathon.repository.MoMeasurementRepository;
 import ani.beautymarathon.repository.UserMeasurementRepository;
 import ani.beautymarathon.repository.UserRepository;
+import ani.beautymarathon.repository.WinnerRepository;
 import ani.beautymarathon.repository.WkMeasurementRepository;
+import ani.beautymarathon.view.UserMaxAverageView;
 import ani.beautymarathon.view.measurement.CreateUserMeasurementView;
 import ani.beautymarathon.view.measurement.filter.register.MoMeasurementFilter;
 import ani.beautymarathon.view.measurement.filter.register.UserMeasurementFilter;
@@ -26,6 +28,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -35,14 +38,19 @@ public class MeasurementService {
     private final WkMeasurementRepository wkMeasurementRepository;
     private final UserMeasurementRepository userMeasurementRepository;
     private final UserRepository userRepository;
+    private final WinnerRepository winnerRepository;
+    private final WinnerService winnerService;
 
     public MeasurementService(MoMeasurementRepository moMeasurementRepository,
                               WkMeasurementRepository wkMeasurementRepository,
-                              UserMeasurementRepository userMeasurementRepository, UserRepository userRepository) {
+                              UserMeasurementRepository userMeasurementRepository, UserRepository userRepository,
+                              WinnerRepository winnerRepository, WinnerService winnerService) {
         this.moMeasurementRepository = moMeasurementRepository;
         this.wkMeasurementRepository = wkMeasurementRepository;
         this.userMeasurementRepository = userMeasurementRepository;
         this.userRepository = userRepository;
+        this.winnerRepository = winnerRepository;
+        this.winnerService = winnerService;
     }
 
     @Transactional
@@ -123,6 +131,43 @@ public class MeasurementService {
         } else {
             return moMeasurementRepository.findAll(pageable);
         }
+    }
+
+    public WkMeasurement getWkById(long id) {
+        return wkMeasurementRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("WkMeasurement with id " + id + " not found"));
+    }
+
+    public WkMeasurement updateWkStatus(long id, ClosedState closedState) {
+        final WkMeasurement wkMeasurement = getWkById(id);
+        wkMeasurement.setClosedState(closedState);
+
+        final WkMeasurement updated = wkMeasurementRepository.save(wkMeasurement);
+        log.info("Status of week with id {} has been updated {}", id, updated);
+        return updated;
+    }
+
+    public MoMeasurement getMoById(long id) {
+        return moMeasurementRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("MoMeasurement with id " + id + " not found"));
+    }
+
+    @Transactional
+    public MoMeasurement updateMoStatus(long moId, ClosedState closedState) {
+        final MoMeasurement moMeasurement = getMoById(moId);
+        moMeasurement.setClosedState(closedState);
+        final MoMeasurement updatedMoMeasurement = moMeasurementRepository.save(moMeasurement);
+        log.info("Status of month with id {} has been updated {}", moId, updatedMoMeasurement);
+
+        if (closedState == ClosedState.OPEN) {
+            return updatedMoMeasurement;
+        }
+
+        List<UserMaxAverageView> userMaxAverageViews = winnerRepository.findUsersWithMaxAverage(moId);
+        winnerService.createWinnersFromViews(userMaxAverageViews, moMeasurement);
+        log.info("The winner of the month has been determined!");
+
+        return updatedMoMeasurement;
     }
 
     private Page<UserMeasurement> searchUserMeasurementsByQbe(UserMeasurementFilter filter, Pageable pageable) {

--- a/src/main/java/ani/beautymarathon/service/MeasurementService.java
+++ b/src/main/java/ani/beautymarathon/service/MeasurementService.java
@@ -153,21 +153,28 @@ public class MeasurementService {
     }
 
     @Transactional
-    public MoMeasurement updateMoStatus(long moId, ClosedState closedState) {
+    public MoMeasurement updateMoStatus(long moId, ClosedState newMoState) {
         final MoMeasurement moMeasurement = getMoById(moId);
-        moMeasurement.setClosedState(closedState);
-        final MoMeasurement updatedMoMeasurement = moMeasurementRepository.save(moMeasurement);
-        log.info("Status of month with id {} has been updated {}", moId, updatedMoMeasurement);
+        final ClosedState currentMoState = moMeasurement.getClosedState();
 
-        if (closedState == ClosedState.OPEN) {
+        if (currentMoState == newMoState) {
+            return moMeasurement;
+        } else {
+            moMeasurement.setClosedState(newMoState);
+            final MoMeasurement updatedMoMeasurement = moMeasurementRepository.save(moMeasurement);
+            log.info("Status of month with id {} has been updated {}", moId, updatedMoMeasurement);
+
+            if (ClosedState.CLOSED == newMoState) {
+
+                List<UserMaxAverageView> userMaxAverageViews = winnerRepository.findUsersWithMaxAverage(moId);
+                winnerService.createWinnersFromViews(userMaxAverageViews, moMeasurement);
+                log.info("The winner of the month has been determined!");
+
+                return updatedMoMeasurement;
+            }
             return updatedMoMeasurement;
+
         }
-
-        List<UserMaxAverageView> userMaxAverageViews = winnerRepository.findUsersWithMaxAverage(moId);
-        winnerService.createWinnersFromViews(userMaxAverageViews, moMeasurement);
-        log.info("The winner of the month has been determined!");
-
-        return updatedMoMeasurement;
     }
 
     private Page<UserMeasurement> searchUserMeasurementsByQbe(UserMeasurementFilter filter, Pageable pageable) {

--- a/src/main/java/ani/beautymarathon/service/WinnerService.java
+++ b/src/main/java/ani/beautymarathon/service/WinnerService.java
@@ -33,7 +33,6 @@ public class WinnerService {
 
             winners.add(winner);
         }
-
         winnerRepository.saveAll(winners);
     }
 }

--- a/src/main/java/ani/beautymarathon/service/WinnerService.java
+++ b/src/main/java/ani/beautymarathon/service/WinnerService.java
@@ -1,8 +1,8 @@
 package ani.beautymarathon.service;
 
 import ani.beautymarathon.entity.MoMeasurement;
+import ani.beautymarathon.entity.User;
 import ani.beautymarathon.entity.Winner;
-import ani.beautymarathon.repository.UserRepository;
 import ani.beautymarathon.repository.WinnerRepository;
 import ani.beautymarathon.view.UserMaxAverageView;
 import org.springframework.stereotype.Service;
@@ -13,22 +13,22 @@ import java.util.List;
 @Service
 public class WinnerService {
     private final WinnerRepository winnerRepository;
-    private final UserRepository userRepository;
     private final UserService userService;
 
-    public WinnerService(WinnerRepository winnerRepository, UserRepository userRepository, UserService userService) {
+    public WinnerService(WinnerRepository winnerRepository, UserService userService) {
         this.winnerRepository = winnerRepository;
-        this.userRepository = userRepository;
         this.userService = userService;
     }
 
     public void createWinnersFromViews(List<UserMaxAverageView> userMaxAverageViews, MoMeasurement moMeasurement) {
-        List<Winner> winners = new ArrayList<>();
+        final List<Winner> winners = new ArrayList<>();
 
         for (UserMaxAverageView userMax : userMaxAverageViews) {
-            Winner winner = new Winner();
+            final Winner winner = new Winner();
             winner.setAveragePoint(userMax.getMaxAverageTotal());
-            winner.setUser(userService.getById(userMax.getUserId()));
+            Long userId = userMax.getUserId();
+            User byId = userService.getById(userId);
+            winner.setUser(byId);
             winner.setMoMeasurement(moMeasurement);
 
             winners.add(winner);
@@ -36,5 +36,4 @@ public class WinnerService {
 
         winnerRepository.saveAll(winners);
     }
-
 }

--- a/src/main/java/ani/beautymarathon/service/WinnerService.java
+++ b/src/main/java/ani/beautymarathon/service/WinnerService.java
@@ -1,0 +1,40 @@
+package ani.beautymarathon.service;
+
+import ani.beautymarathon.entity.MoMeasurement;
+import ani.beautymarathon.entity.Winner;
+import ani.beautymarathon.repository.UserRepository;
+import ani.beautymarathon.repository.WinnerRepository;
+import ani.beautymarathon.view.UserMaxAverageView;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class WinnerService {
+    private final WinnerRepository winnerRepository;
+    private final UserRepository userRepository;
+    private final UserService userService;
+
+    public WinnerService(WinnerRepository winnerRepository, UserRepository userRepository, UserService userService) {
+        this.winnerRepository = winnerRepository;
+        this.userRepository = userRepository;
+        this.userService = userService;
+    }
+
+    public void createWinnersFromViews(List<UserMaxAverageView> userMaxAverageViews, MoMeasurement moMeasurement) {
+        List<Winner> winners = new ArrayList<>();
+
+        for (UserMaxAverageView userMax : userMaxAverageViews) {
+            Winner winner = new Winner();
+            winner.setAveragePoint(userMax.getMaxAverageTotal());
+            winner.setUser(userService.getById(userMax.getUserId()));
+            winner.setMoMeasurement(moMeasurement);
+
+            winners.add(winner);
+        }
+
+        winnerRepository.saveAll(winners);
+    }
+
+}

--- a/src/main/java/ani/beautymarathon/service/WinnerService.java
+++ b/src/main/java/ani/beautymarathon/service/WinnerService.java
@@ -26,9 +26,9 @@ public class WinnerService {
         for (UserMaxAverageView userMax : userMaxAverageViews) {
             final Winner winner = new Winner();
             winner.setAveragePoint(userMax.getMaxAverageTotal());
-            Long userId = userMax.getUserId();
-            User byId = userService.getById(userId);
-            winner.setUser(byId);
+            final Long userMaxId = userMax.getUserId();
+            final User winnerUserId = userService.getById(userMaxId);
+            winner.setUser(winnerUserId);
             winner.setMoMeasurement(moMeasurement);
 
             winners.add(winner);

--- a/src/main/java/ani/beautymarathon/view/UserMaxAverageView.java
+++ b/src/main/java/ani/beautymarathon/view/UserMaxAverageView.java
@@ -1,0 +1,6 @@
+package ani.beautymarathon.view;
+
+public interface UserMaxAverageView {
+        Long getUserId();
+        Double getMaxAverageTotal();
+}

--- a/src/main/java/ani/beautymarathon/view/measurement/UpdateUserMeasurementView.java
+++ b/src/main/java/ani/beautymarathon/view/measurement/UpdateUserMeasurementView.java
@@ -1,0 +1,56 @@
+package ani.beautymarathon.view.measurement;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record UpdateUserMeasurementView(
+
+        @Min(30)
+        @Max(200)
+        @NotNull
+        @JsonProperty("weight")
+        BigDecimal weight,
+
+        @Min(0)
+        @Max(5)
+        @NotNull
+        @JsonProperty("weightPoint")
+        Integer weightPoint,
+
+        @Min(0)
+        @Max(10)
+        @NotNull
+        @JsonProperty("sleepPoint")
+        Integer sleepPoint,
+
+        @Min(0)
+        @Max(10)
+        @NotNull
+        @JsonProperty("waterPoint")
+        Integer waterPoint,
+
+        @Min(0)
+        @Max(10)
+        @NotNull
+        @JsonProperty("stepPoint")
+        Integer stepPoint,
+
+        @Min(0)
+        @Max(10)
+        @NotNull
+        @JsonProperty("diaryPoint")
+        Integer diaryPoint,
+
+        @Min(0)
+        @Max(10)
+        @NotNull
+        @JsonProperty("alcoholFreePoints")
+        Integer alcoholFreePoints,
+
+        @JsonProperty("commentary")
+        String commentary
+) {}

--- a/src/main/resources/db/migration/V5__create_table_winner.sql
+++ b/src/main/resources/db/migration/V5__create_table_winner.sql
@@ -1,13 +1,13 @@
 CREATE TABLE IF NOT EXISTS winner
 (
     id                BIGSERIAL PRIMARY KEY,
-    mo_measurement_id BIGINT NOT NULL
-        CONSTRAINT user_measurement_user_profile_fk
-            REFERENCES user_profile (id)
+    mo_measurement_id BIGINT NOT NULL UNIQUE
+        CONSTRAINT winner_mo_measurement_fk
+            REFERENCES mo_measurement (id)
             ON DELETE CASCADE,
     user_id           BIGINT NOT NULL
         CONSTRAINT winner_user_profile_fk
             REFERENCES user_profile (id),
     average_point     NUMERIC(3,1) NOT NULL,
-    creation_date DATE DEFAULT NOW()
+    creation_date     DATE DEFAULT NOW()
 );

--- a/src/main/resources/db/migration/V5__create_table_winner.sql
+++ b/src/main/resources/db/migration/V5__create_table_winner.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS winner
+(
+    id                BIGSERIAL PRIMARY KEY,
+    mo_measurement_id BIGINT NOT NULL
+        CONSTRAINT user_measurement_user_profile_fk
+            REFERENCES user_profile (id)
+            ON DELETE CASCADE,
+    user_id           BIGINT NOT NULL
+        CONSTRAINT winner_user_profile_fk
+            REFERENCES user_profile (id),
+    average_point     NUMERIC(3,1) NOT NULL,
+    creation_date DATE DEFAULT NOW()
+);

--- a/src/main/resources/db/migration/V6__add_column_email_to_user_profile.sql
+++ b/src/main/resources/db/migration/V6__add_column_email_to_user_profile.sql
@@ -1,0 +1,5 @@
+ALTER TABLE user_profile
+    ADD column email VARCHAR(255);
+CREATE UNIQUE INDEX index_email
+    ON user_profile (email)
+    WHERE email IS NOT NULL;


### PR DESCRIPTION
Add a table "winners" and logic for automatically creating a winner at month-end closing. To do this, add methods for opening and closing weeks and months to MeasurementController and a complete package for the winner table: entity, repository, controller and service. Add to the database up-to-date information: user profiles, weeks and months